### PR TITLE
Fix implicit declaration warning + unused var

### DIFF
--- a/driver-opencl.c
+++ b/driver-opencl.c
@@ -385,7 +385,6 @@ char *set_gpu_memclock(char *arg)
 {
 	int i, val = 0, exit_val = 0, device = 0;
 	char *nextptr;
-	char *valuesptr;
 
 	nextptr = strtok(arg, ",");
 	if (nextptr == NULL)

--- a/miner.h
+++ b/miner.h
@@ -1129,6 +1129,8 @@ extern void api(int thr_id);
 extern struct pool *current_pool(void);
 extern int enabled_pools;
 extern void get_intrange(char *arg, int *val1, int *val2);
+extern void get_intexitval(char *arg, int *val1, int *val2);
+extern void get_intrangeexitval(char *arg, int *val1, int *val2, int *val3);
 extern bool detect_stratum(struct pool *pool, char *url);
 extern void print_summary(void);
 extern void adjust_quota_gcd(void);


### PR DESCRIPTION
fixed warnings:

```
  CC     cgminer-driver-opencl.o
driver-opencl.c: In function 'set_gpu_engine':
driver-opencl.c:318: warning: implicit declaration of function 'get_intrangeexitval'
driver-opencl.c: In function 'set_gpu_memclock':
driver-opencl.c:393: warning: implicit declaration of function 'get_intexitval'
driver-opencl.c:388: warning: unused variable 'valuesptr'
```
