### PR TITLE
API: Added two more decimal places to MH/s.

### DIFF
--- a/api.c
+++ b/api.c
@@ -1190,7 +1190,7 @@ static struct api_data *print_data(struct api_data *root, char *buf, bool isjson
 			case API_UTILITY:
 			case API_FREQ:
 			case API_MHS:
-				sprintf(buf, "%.2f", *((double *)(root->data)));
+				sprintf(buf, "%.4f", *((double *)(root->data)));
 				break;
 			case API_VOLTS:
 				sprintf(buf, "%.3f", *((float *)(root->data)));


### PR DESCRIPTION
At the moment, getting data from the API results in getting mh/s as "0.25" for "250kh/s". I'd like a little more precision. I'd like it to display as "0.2563" so that when I grab the information from the API, I can convert it to "256.3 kh/s"
